### PR TITLE
feat: Enhance Language Fetching, Add CDN Support, and Introduce Tolgee.translate Method

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -108,18 +108,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -148,18 +148,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -217,10 +217,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   tolgee:
     dependency: "direct main"
     description:
@@ -248,10 +248,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -100,18 +100,34 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
-  js:
+    version: "0.19.0"
+  leak_tracker:
     dependency: transitive
     description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -124,34 +140,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -161,26 +177,26 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -201,10 +217,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.7.0"
   tolgee:
     dependency: "direct main"
     description:
@@ -228,6 +244,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.2.1"
 sdks:
-  dart: ">=3.0.2 <4.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/src/api/models/tolgee_translation_model.dart
+++ b/lib/src/api/models/tolgee_translation_model.dart
@@ -1,5 +1,5 @@
 class TolgeeTranslationModel {
-  final String text;
+  final String? text;
 
   const TolgeeTranslationModel({
     required this.text,

--- a/lib/src/api/responses/tolgee_all_project_languages_response.dart
+++ b/lib/src/api/responses/tolgee_all_project_languages_response.dart
@@ -15,7 +15,7 @@ class TolgeeAllProjectLanguagesResponse {
   /// Creates new instance of [TolgeeAllProjectLanguagesResponse] from JSON string
   static fromJsonString(String jsonString) {
     final jsonBody = jsonDecode(jsonString);
-    final languages = jsonBody['_embedded']['languages'] as List;
+    final languages = jsonBody['_embedded']?['languages'] as List? ?? [];
     final languageModels = languages.map((key) {
       final name = key['name'] as String;
       final tag = key['tag'] as String;

--- a/lib/src/api/responses/tolgee_translations_response.dart
+++ b/lib/src/api/responses/tolgee_translations_response.dart
@@ -16,7 +16,7 @@ class TolgeeTranslationsResponse {
 
   static TolgeeTranslationsResponse fromJsonString(String jsonString) {
     final jsonBody = jsonDecode(jsonString);
-    final keys = jsonBody['_embedded']['keys'] as List;
+    final keys = jsonBody['_embedded']?['keys'] as List? ?? [];
     final keysModels = keys.map((key) {
       try {
         return TolgeeKeyModel.fromJson(key);

--- a/lib/src/api/responses/tolgee_translations_response.dart
+++ b/lib/src/api/responses/tolgee_translations_response.dart
@@ -15,7 +15,11 @@ class TolgeeTranslationsResponse {
     final jsonBody = jsonDecode(jsonString);
     final keys = jsonBody['_embedded']['keys'] as List;
     final keysModels = keys.map((key) {
-      return TolgeeKeyModel.fromJson(key);
+      try {
+        return TolgeeKeyModel.fromJson(key);
+      } catch (e) {
+        return TolgeeKeyModel(keyId: key, keyName: key, translations: {});
+      }
     }).toList();
     final page = jsonBody['page'];
     return TolgeeTranslationsResponse(

--- a/lib/src/api/responses/tolgee_translations_response.dart
+++ b/lib/src/api/responses/tolgee_translations_response.dart
@@ -9,7 +9,10 @@ class TolgeeTranslationsResponse {
   final int currentPage;
 
   const TolgeeTranslationsResponse(
-      this.keys, this.totalPages, this.currentPage);
+    this.keys,
+    this.totalPages,
+    this.currentPage,
+  );
 
   static TolgeeTranslationsResponse fromJsonString(String jsonString) {
     final jsonBody = jsonDecode(jsonString);

--- a/lib/src/api/responses/tolgee_translations_response.dart
+++ b/lib/src/api/responses/tolgee_translations_response.dart
@@ -3,17 +3,25 @@ import 'dart:convert';
 import 'package:tolgee/src/api/models/tolgee_key_model.dart';
 
 class TolgeeTranslationsResponse {
-  /// List of languages in Tolgee project
+  /// List of keys in Tolgee project
   final List<TolgeeKeyModel> keys;
+  final int totalPages;
+  final int currentPage;
 
-  const TolgeeTranslationsResponse(this.keys);
+  const TolgeeTranslationsResponse(
+      this.keys, this.totalPages, this.currentPage);
 
-  static fromJsonString(String jsonString) {
+  static TolgeeTranslationsResponse fromJsonString(String jsonString) {
     final jsonBody = jsonDecode(jsonString);
     final keys = jsonBody['_embedded']['keys'] as List;
     final keysModels = keys.map((key) {
       return TolgeeKeyModel.fromJson(key);
-    });
-    return TolgeeTranslationsResponse(keysModels.toList());
+    }).toList();
+    final page = jsonBody['page'];
+    return TolgeeTranslationsResponse(
+      keysModels,
+      page['totalPages'],
+      page['number'],
+    );
   }
 }

--- a/lib/src/api/tolgee_api.dart
+++ b/lib/src/api/tolgee_api.dart
@@ -48,7 +48,9 @@ class TolgeeApi {
       );
 
       if (response.statusCode == 200) {
-        final body = TolgeeTranslationsResponse.fromJsonString(response.body);
+        final utf8DecodedBody = utf8.decode(response.bodyBytes);
+
+        final body = TolgeeTranslationsResponse.fromJsonString(utf8DecodedBody);
         allTranslations.addAll(body.keys);
         totalPages = body.totalPages;
         currentPage++;

--- a/lib/src/api/tolgee_api.dart
+++ b/lib/src/api/tolgee_api.dart
@@ -54,8 +54,6 @@ class TolgeeApi {
         allTranslations.addAll(body.keys);
         totalPages = body.totalPages;
         currentPage++;
-      } else {
-        throw Exception('Failed to load translations');
       }
     }
 

--- a/lib/src/api/tolgee_api.dart
+++ b/lib/src/api/tolgee_api.dart
@@ -8,6 +8,7 @@ import 'package:tolgee/src/api/responses/tolgee_translations_response.dart';
 import 'package:tolgee/src/api/responses/update_translations_response.dart';
 import 'package:tolgee/src/api/tolgee_config.dart';
 import 'package:tolgee/src/api/tolgee_project_language.dart';
+import 'package:tolgee/src/logger/logger.dart';
 
 import 'models/tolgee_key_model.dart';
 
@@ -47,6 +48,7 @@ class TolgeeApi {
     List<TolgeeKeyModel> allTranslations = [];
     int currentPage = 0;
     int totalPages = 1; // Initialize to 1 to enter the loop
+    int retries = 3;
 
     while (currentPage < totalPages) {
       final response = await get(
@@ -65,6 +67,12 @@ class TolgeeApi {
         allTranslations.addAll(body.keys);
         totalPages = body.totalPages;
         currentPage++;
+      } else {
+        retries--;
+        if (retries <= 0) {
+          TolgeeLogger.warning('Failed to fetch translations');
+          return const TolgeeTranslationsResponse([], 0, 0);
+        }
       }
     }
 

--- a/lib/src/api/tolgee_config.dart
+++ b/lib/src/api/tolgee_config.dart
@@ -6,12 +6,20 @@ class TolgeeConfig {
   /// The URL of your Tolgee server.
   final String apiUrl;
 
+  // CDN URL
+  final String? cdnUrl;
+
+  // Should use CDN
+  final bool useCDN;
+
   /// Creates a new TolgeeConfig instance.
   ///
   /// The [apiKey] and [apiUrl] parameters must not be null.
   const TolgeeConfig({
     required this.apiKey,
     required this.apiUrl,
+    this.cdnUrl,
+    this.useCDN = false,
   });
 
   @override

--- a/lib/src/l10n/tolgee_localization.dart
+++ b/lib/src/l10n/tolgee_localization.dart
@@ -28,7 +28,7 @@ class TolgeeLocalization {
     ];
   }
 
-  String translate(String key) {
+  String? translate(String key) {
     return TolgeeTranslationsStrategy.instance.translate(key);
   }
 }

--- a/lib/src/sdk/tolgee.dart
+++ b/lib/src/sdk/tolgee.dart
@@ -59,4 +59,9 @@ class Tolgee {
   static void highlightTolgeeWidgets() {
     TolgeeTranslationsStrategy.instance.toggleTranslationEnabled();
   }
+
+  static String translate({required String key, String? defaultValue}) {
+    String translatedValue = TolgeeTranslationsStrategy.instance.translate(key);
+    return translatedValue == key ? defaultValue ?? key : translatedValue;
+  }
 }

--- a/lib/src/sdk/tolgee.dart
+++ b/lib/src/sdk/tolgee.dart
@@ -21,7 +21,7 @@ class Tolgee {
     String? currentLanguage,
     bool useCDN = false,
   }) async {
-    apiKey != null && apiUrl != null && currentLanguage != null
+    apiKey != null && apiUrl != null
         ? await TolgeeTranslationsStrategy.initRemote(
             currentLanguage: currentLanguage,
             apiKey: apiKey,
@@ -29,7 +29,7 @@ class Tolgee {
             cdnUrl: cdnUrl,
             useCDN: useCDN,
           )
-        : await TolgeeTranslationsStrategy.initStatic();
+        : await TolgeeTranslationsStrategy.initStatic(currentLanguage);
   }
 
   /// Returns the base language

--- a/lib/src/sdk/tolgee.dart
+++ b/lib/src/sdk/tolgee.dart
@@ -61,7 +61,8 @@ class Tolgee {
   }
 
   static String translate({required String key, String? defaultValue}) {
-    String translatedValue = TolgeeTranslationsStrategy.instance.translate(key);
-    return translatedValue == key ? defaultValue ?? key : translatedValue;
+    String? translatedValue =
+        TolgeeTranslationsStrategy.instance.translate(key);
+    return translatedValue ?? defaultValue ?? key;
   }
 }

--- a/lib/src/sdk/tolgee.dart
+++ b/lib/src/sdk/tolgee.dart
@@ -14,13 +14,20 @@ class Tolgee {
   /// Tolgee will be initialized in remote mode.
   /// In remote mode, translations will be fetched from Tolgee Cloud.
   /// In static mode, translations will be fetched from local files.
-  static Future<void> init(
-      {String? apiKey, String? apiUrl, String? currentLanguage}) async {
+  static Future<void> init({
+    String? apiKey,
+    String? apiUrl,
+    String? cdnUrl,
+    String? currentLanguage,
+    bool useCDN = false,
+  }) async {
     apiKey != null && apiUrl != null && currentLanguage != null
         ? await TolgeeTranslationsStrategy.initRemote(
             currentLanguage: currentLanguage,
             apiKey: apiKey,
             apiUrl: apiUrl,
+            cdnUrl: cdnUrl,
+            useCDN: useCDN,
           )
         : await TolgeeTranslationsStrategy.initStatic();
   }

--- a/lib/src/translations/tolgee_remote_translations.dart
+++ b/lib/src/translations/tolgee_remote_translations.dart
@@ -9,6 +9,25 @@ import '../api/requests/update_translations_request.dart';
 import '../api/tolgee_api.dart';
 import '../api/tolgee_project_language.dart';
 
+String normalizeLanguageCode(String languageCode) {
+  // Split the language code by underscore
+  List<String> parts = languageCode.split('_');
+
+  if (parts.length != 2) {
+    // If the format is incorrect, return the original code or handle the error
+    return languageCode;
+  }
+
+  // Convert the first part (language) to lowercase
+  String language = parts[0].toLowerCase();
+
+  // Convert the second part (country) to uppercase
+  String country = parts[1].toUpperCase();
+
+  // Join the parts with a hyphen
+  return '$language-$country';
+}
+
 class TolgeeRemoteTranslations extends ChangeNotifier
     implements TolgeeTranslations {
   TolgeeConfig? _config;
@@ -68,12 +87,13 @@ class TolgeeRemoteTranslations extends ChangeNotifier
     );
 
     if (value == null) {
-      return key;
+      return null;
     }
 
-    final translation = value.translations[currentLanguage.toLanguageTag()];
+    final translation = value
+        .translations[normalizeLanguageCode(currentLanguage.toLanguageTag())];
     if (translation == null) {
-      return key;
+      return null;
     }
 
     return translation.text;

--- a/lib/src/translations/tolgee_remote_translations.dart
+++ b/lib/src/translations/tolgee_remote_translations.dart
@@ -50,7 +50,9 @@ class TolgeeRemoteTranslations extends ChangeNotifier
   Future<void> setCurrentLanguage(Locale locale) async {
     _currentLanguage = locale;
     translations = await TolgeeApi.getTranslations(
-        config: _config!, currentLanguage: locale.toString());
+      config: _config!,
+      currentLanguage: locale.toString(),
+    );
     TolgeeLogger.debug('jsonBody: $translations');
     TolgeeRemoteTranslations.instance._translations = translations!.keys;
     notifyListeners();
@@ -106,13 +108,18 @@ class TolgeeRemoteTranslations extends ChangeNotifier
   static final instance = TolgeeRemoteTranslations._();
   TolgeeRemoteTranslations._();
 
-  static Future<void> init(
-      {required String apiKey,
-      required String apiUrl,
-      required String currentLanguage}) async {
+  static Future<void> init({
+    required String apiKey,
+    required String apiUrl,
+    required String currentLanguage,
+    String? cdnUrl,
+    bool useCDN = false,
+  }) async {
     final config = TolgeeConfig(
       apiKey: apiKey,
       apiUrl: apiUrl,
+      cdnUrl: cdnUrl,
+      useCDN: useCDN,
     );
 
     instance._config = config;

--- a/lib/src/translations/tolgee_remote_translations.dart
+++ b/lib/src/translations/tolgee_remote_translations.dart
@@ -66,6 +66,7 @@ class TolgeeRemoteTranslations extends ChangeNotifier
     final value = _translations.firstWhereOrNull(
       (element) => element.keyName == key,
     );
+
     if (value == null) {
       return key;
     }

--- a/lib/src/translations/tolgee_remote_translations.dart
+++ b/lib/src/translations/tolgee_remote_translations.dart
@@ -57,7 +57,7 @@ class TolgeeRemoteTranslations extends ChangeNotifier
   Map<String, TolgeeProjectLanguage> _projectLanguages = {};
 
   @override
-  String translate(String key) {
+  String? translate(String key) {
     final currentLanguage = _currentLanguage;
     if (currentLanguage == null) {
       return key;

--- a/lib/src/translations/tolgee_static_translations.dart
+++ b/lib/src/translations/tolgee_static_translations.dart
@@ -12,7 +12,7 @@ class TolgeeStaticTranslations implements TolgeeTranslations {
   Map<String, TolgeeProjectLanguage> _projectLanguages = {};
   Set<TolgeeKeyModel> _translations = {};
 
-  static Future<void> init() async {
+  static Future<void> init(String? currentLanguage) async {
     WidgetsFlutterBinding.ensureInitialized();
     final manifest = await AssetManifest.loadFromAssetBundle(rootBundle);
 
@@ -75,6 +75,7 @@ class TolgeeStaticTranslations implements TolgeeTranslations {
     }
 
     instance._currentLanguage = Locale(
+      currentLanguage ??
       projectLanguages.values.firstWhere((element) => element.base).tag,
     );
     instance._projectLanguages = projectLanguages;
@@ -103,17 +104,16 @@ class TolgeeStaticTranslations implements TolgeeTranslations {
   }
 
   @override
-  String translate(String key) {
+  String? translate(String key) {
     final languageCode = _currentLanguage?.languageCode;
     if (languageCode == null) {
-      return key;
+      return null;
     }
 
     return _translations
             .firstWhere((element) => element.keyName == key)
             .translations[languageCode]
-            ?.text ??
-        key;
+            ?.text;
   }
 
   @override

--- a/lib/src/translations/tolgee_translation_strategy.dart
+++ b/lib/src/translations/tolgee_translation_strategy.dart
@@ -10,9 +10,17 @@ class TolgeeTranslationsStrategy extends ChangeNotifier
   static Future<void> initRemote({
     required String apiKey,
     required String apiUrl,
-    required String currentLanguage
+    required String currentLanguage,
+    String? cdnUrl,
+    bool useCDN = false,
   }) async {
-    await TolgeeRemoteTranslations.init(apiKey: apiKey, apiUrl: apiUrl,currentLanguage: currentLanguage);
+    await TolgeeRemoteTranslations.init(
+      apiKey: apiKey,
+      apiUrl: apiUrl,
+      currentLanguage: currentLanguage,
+      cdnUrl: cdnUrl,
+      useCDN: useCDN,
+    );
     TolgeeTranslationsStrategy.instance._tolgeeTranslations =
         TolgeeRemoteTranslations.instance;
 
@@ -41,7 +49,7 @@ class TolgeeTranslationsStrategy extends ChangeNotifier
   Locale? get currentLanguage => _tolgeeTranslations?.currentLanguage;
 
   @override
-  Future<void>setCurrentLanguage(Locale locale) async{
+  Future<void> setCurrentLanguage(Locale locale) async {
     await _tolgeeTranslations?.setCurrentLanguage(locale);
   }
 

--- a/lib/src/translations/tolgee_translation_strategy.dart
+++ b/lib/src/translations/tolgee_translation_strategy.dart
@@ -50,8 +50,8 @@ class TolgeeTranslationsStrategy extends ChangeNotifier
   }
 
   @override
-  String translate(String key) {
-    return _tolgeeTranslations?.translate(key) ?? key;
+  String? translate(String key) {
+    return _tolgeeTranslations?.translate(key);
   }
 
   @override

--- a/lib/src/translations/tolgee_translation_strategy.dart
+++ b/lib/src/translations/tolgee_translation_strategy.dart
@@ -10,7 +10,7 @@ class TolgeeTranslationsStrategy extends ChangeNotifier
   static Future<void> initRemote({
     required String apiKey,
     required String apiUrl,
-    required String currentLanguage,
+    required String? currentLanguage,
     String? cdnUrl,
     bool useCDN = false,
   }) async {
@@ -21,21 +21,30 @@ class TolgeeTranslationsStrategy extends ChangeNotifier
       cdnUrl: cdnUrl,
       useCDN: useCDN,
     );
-    TolgeeTranslationsStrategy.instance._tolgeeTranslations =
+    TolgeeTranslationsStrategy.instance.__tolgeeTranslations =
         TolgeeRemoteTranslations.instance;
 
     TolgeeRemoteTranslations.instance.addListener(() {
       TolgeeTranslationsStrategy.instance.notifyListeners();
     });
+    TolgeeTranslationsStrategy.instance._initialized = true;
   }
 
-  static Future<void> initStatic() async {
-    await TolgeeStaticTranslations.init();
-    TolgeeTranslationsStrategy.instance._tolgeeTranslations =
+  static Future<void> initStatic(String? currentLanguage) async {
+    await TolgeeStaticTranslations.init(currentLanguage);
+    TolgeeTranslationsStrategy.instance.__tolgeeTranslations =
         TolgeeStaticTranslations.instance;
+    TolgeeTranslationsStrategy.instance._initialized = true;
   }
 
-  TolgeeTranslations? _tolgeeTranslations;
+  bool _initialized = false;
+  late final TolgeeTranslations __tolgeeTranslations;
+  TolgeeTranslations get _tolgeeTranslations {
+    if (!_initialized) {
+      throw Exception("Tolgee integration is not initialized");
+    }
+    return __tolgeeTranslations;
+  }
   static final TolgeeTranslationsStrategy instance =
       TolgeeTranslationsStrategy._();
 
@@ -43,36 +52,45 @@ class TolgeeTranslationsStrategy extends ChangeNotifier
 
   @override
   Map<String, TolgeeProjectLanguage> get allProjectLanguages =>
-      _tolgeeTranslations?.allProjectLanguages ?? {};
+      _tolgeeTranslations.allProjectLanguages;
 
   @override
-  Locale? get currentLanguage => _tolgeeTranslations?.currentLanguage;
+  Locale? get currentLanguage => _tolgeeTranslations.currentLanguage;
 
   @override
   Future<void> setCurrentLanguage(Locale locale) async {
-    await _tolgeeTranslations?.setCurrentLanguage(locale);
+    await _tolgeeTranslations.setCurrentLanguage(locale);
   }
 
   @override
   void toggleTranslationEnabled() {
-    _tolgeeTranslations?.toggleTranslationEnabled();
+    if (!_initialized) {
+      return;
+    }
+    _tolgeeTranslations.toggleTranslationEnabled();
   }
 
   @override
   String? translate(String key) {
-    return _tolgeeTranslations?.translate(key);
+    if (!_initialized) {
+      return null;
+    }
+    return _tolgeeTranslations.translate(key);
   }
 
   @override
   Set<TolgeeKeyModel> translationForKeys(Set<String> keys) {
-    return _tolgeeTranslations?.translationForKeys(keys) ?? {};
+    if (!_initialized) {
+      return {};
+    }
+    return _tolgeeTranslations.translationForKeys(keys);
   }
 
   @override
   void updateKeyModel({
     required TolgeeKeyModel updatedKeyModel,
   }) {
-    _tolgeeTranslations?.updateKeyModel(updatedKeyModel: updatedKeyModel);
+    _tolgeeTranslations.updateKeyModel(updatedKeyModel: updatedKeyModel);
   }
 
   @override
@@ -80,12 +98,13 @@ class TolgeeTranslationsStrategy extends ChangeNotifier
     required String key,
     required Map<String, String> translations,
   }) {
-    return _tolgeeTranslations?.updateTranslations(
-            key: key, translations: translations) ??
-        Future.value();
+    return _tolgeeTranslations.updateTranslations(
+      key: key,
+      translations: translations,
+    );
   }
 
   @override
   bool get isTranslationEnabled =>
-      _tolgeeTranslations?.isTranslationEnabled ?? false;
+      _tolgeeTranslations.isTranslationEnabled;
 }

--- a/lib/src/translations/tolgee_translations.dart
+++ b/lib/src/translations/tolgee_translations.dart
@@ -15,7 +15,7 @@ abstract class TolgeeTranslations {
     required TolgeeKeyModel updatedKeyModel,
   });
 
-  String translate(String key);
+  String? translate(String key);
 
   Set<TolgeeKeyModel> translationForKeys(Set<String> keys);
 

--- a/lib/src/ui/translation_pop_up.dart
+++ b/lib/src/ui/translation_pop_up.dart
@@ -105,7 +105,7 @@ class _TranslationPopUpState extends State<TranslationPopUp> {
                     await TolgeeRemoteTranslations.instance.updateTranslations(
                       key: widget.translationModel.keyName,
                       translations: widget.translationModel.translations.map(
-                        (key, value) => MapEntry(key, value.text),
+                        (key, value) => MapEntry(key, value.text ?? ''),
                       ),
                     );
                     if (mounted) {

--- a/lib/src/ui/translation_widget.dart
+++ b/lib/src/ui/translation_widget.dart
@@ -88,12 +88,11 @@ class _TranslationWidgetState extends State<TranslationWidget> {
   }
 
   String _translate(String key, [Map<String, Object>? args]) {
+    final result = TolgeeTranslationsStrategy.instance.translate(key) ?? key;
     if (args == null) {
-      return TolgeeTranslationsStrategy.instance.translate(key) ?? key;
+      return result;
     }
-    return MessageFormat(
-      TolgeeTranslationsStrategy.instance.translate(key) ?? key,
-    ).format(args);
+    return MessageFormat(result).format(args);
   }
 
   @override

--- a/lib/src/ui/translation_widget.dart
+++ b/lib/src/ui/translation_widget.dart
@@ -89,10 +89,10 @@ class _TranslationWidgetState extends State<TranslationWidget> {
 
   String _translate(String key, [Map<String, Object>? args]) {
     if (args == null) {
-      return TolgeeTranslationsStrategy.instance.translate(key);
+      return TolgeeTranslationsStrategy.instance.translate(key) ?? key;
     }
     return MessageFormat(
-      TolgeeTranslationsStrategy.instance.translate(key),
+      TolgeeTranslationsStrategy.instance.translate(key) ?? key,
     ).format(args);
   }
 

--- a/lib/src/utils/tolgee_translation_model_extension.dart
+++ b/lib/src/utils/tolgee_translation_model_extension.dart
@@ -12,7 +12,7 @@ extension TolgeeKeyModelExtension on TolgeeKeyModel {
       String translationText = 'Not translated yet';
 
       if (translation != null) {
-        translationText = translation.text;
+        translationText = translation.text ?? '';
       }
 
       return '$languageCode $translationText';


### PR DESCRIPTION
Supersedes #4

Includes all changes by @TobiasDuelli and @Maksy05, plus some changes on top to fix some issues and improve compatibility for existing codebases, namely:
- There was a bug where an invalid API key would result in an endless loop trying to fetch the first page of translations (since no response would ever result in 200 HTTP code)
- Propagated `currentLanguage` also to the static translations initializer
- Allow omitting `currentLanguage` from the initializer to fall back to the device's default language (this still isn't ideal since there could be a better language available if the device default isn't available).
- Updated the translate method in static translations to allow setting the default value for non-translated strings, following the remote translations example.

One known breaking change remains: `setCurrentLanguage` is now asynchronous, so it does not immediately change the language.