### PR TITLE
Enabled customBoxDecoration

### DIFF
--- a/lib/src/ui/translation_widget.dart
+++ b/lib/src/ui/translation_widget.dart
@@ -15,9 +15,14 @@ typedef TranslatedWidgetBuilder = Widget Function(
 
 class TranslationWidget extends StatefulWidget {
   final TranslatedWidgetBuilder builder;
+
+  /// Enabled Custom BoxDecoration
+  final BoxDecoration? enabledBoxDecoration;
+
   const TranslationWidget({
     super.key,
     required this.builder,
+    this.enabledBoxDecoration,
   });
 
   @override
@@ -72,7 +77,7 @@ class _TranslationWidgetState extends State<TranslationWidget> {
       },
       behavior: HitTestBehavior.deferToChild,
       child: Container(
-        decoration: kGradientBoxDecoration,
+        decoration: widget.enabledBoxDecoration ?? kGradientBoxDecoration,
         child: AbsorbPointer(
           absorbing: true,
           child: widget.builder(


### PR DESCRIPTION
**Description**
This PR adds an `enabledBoxDecoration` property to `TranslationWidget`, allowing for custom `BoxDecoration` styling on the `_enabled` widget. Defaults to the current gradient if no custom decoration is provided.

**Changes**
- Added `enabledBoxDecoration` property.
- Updated `_buildEnabledWidget` to apply enabledBoxDecoration.

**Example**
`TranslationWidget(
  builder: (context, tr) => Text(tr('title')),
  enabledBoxDecoration: BoxDecoration(
    color: Colors.blueAccent.withOpacity(0.2),
    borderRadius: BorderRadius.circular(8),
  ),
);
`
closes #6 
